### PR TITLE
Standardize on the emberx directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ as:
 
 ## EmberX
 
-emberx-slider is part of the "missing components of ember" collectively
-known as emberx. See also:
+emberx-select is part of the "missing components of ember" collectively
+known as emberx:
 
 * [emberx-select](https://github.com/thefrontside/emberx-select)
+* [emberx-slider](https://github.com/thefrontside/emberx-slider)
+* [emberx-file-input](https://github.com/thefrontside/emberx-file-input)
 
 ## Installation
 


### PR DESCRIPTION
It's confusing that it's different in different readmes. It should just
be a single block that you can see everywhere.... even if that means
including the link to a repository within its own readme