### PR TITLE
Add list to attribute bindings

### DIFF
--- a/addon/components/x-slider.js
+++ b/addon/components/x-slider.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend(PropertyBindings, {
   tagName: ['input'],
   classNames: ['x-slider'],
   propertyBindings: ['value > element.value'],
-  attributeBindings: ['min', 'max', 'step', 'type', 'name'],
+  attributeBindings: ['min', 'max', 'step', 'type', 'name', 'list'],
 
   /**
    * The minimum value that this component's `value` property may


### PR DESCRIPTION
Add list to the list of attribute bindings so that tick marks can be added to the slider. See: http://thenewcode.com/757/Playing-With-The-HTML5-range-Slider-Input.